### PR TITLE
address-tool に差分比較・重複チェック・CSV ドロップ読込を追加

### DIFF
--- a/address-tool.html
+++ b/address-tool.html
@@ -64,6 +64,20 @@
             resize: vertical;
         }
 
+        .drop-zone {
+            border: 2px dashed #b8c6d1;
+            border-radius: 10px;
+            padding: 14px;
+            background: #f8fbfd;
+            transition: border-color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .drop-zone.is-dragover {
+            border-color: #3498db;
+            background: #eef7fd;
+            box-shadow: inset 0 0 0 1px rgba(52, 152, 219, 0.15);
+        }
+
         select {
             min-height: 46px;
             background: #fff;
@@ -76,6 +90,35 @@
             flex-wrap: wrap;
             gap: 10px;
             margin-top: 14px;
+        }
+
+        .tab-row {
+            display: flex;
+            gap: 10px;
+            margin-bottom: 18px;
+            flex-wrap: wrap;
+        }
+
+        .tab-button {
+            background: #dfe8ee;
+            color: #2c3e50;
+        }
+
+        .tab-button:hover {
+            background: #cfdbe4;
+        }
+
+        .tab-button.is-active {
+            background: #3498db;
+            color: #fff;
+        }
+
+        .tool-panel {
+            display: none;
+        }
+
+        .tool-panel.is-active {
+            display: block;
         }
 
         button,
@@ -169,6 +212,10 @@
             flex-wrap: wrap;
         }
 
+        .result-grid.two-column {
+            grid-template-columns: repeat(2, minmax(0, 1fr));
+        }
+
         @media (max-width: 768px) {
             .result-grid {
                 grid-template-columns: 1fr;
@@ -187,15 +234,22 @@
             <a href="index.html" class="link-button secondary">← 座標取得ツールへ戻る</a>
         </div>
 
+        <div class="tab-row">
+            <button id="extract-tab-btn" class="tab-button is-active" type="button">抽出・比較</button>
+            <button id="duplicate-tab-btn" class="tab-button" type="button">重複チェック</button>
+        </div>
+
+        <div id="extract-panel" class="tool-panel is-active">
         <section class="card">
             <div class="description">
                 入力CSVはヘッダー行付きでも利用できます。抽出ルールは以下のとおりです。<br>
-                追加済みの境界データは、下のプルダウンから <strong>広島市 / 京都市 / 埼玉西部</strong> のように選んで、CSVなしで住所データを作成できます。<br>
+                追加済みの境界データは、下のプルダウンから <strong>広島市 / 倉敷市 / 京都市 / 埼玉西部</strong> のように選んで、CSVなしで住所データを作成できます。<br>
                 1列目: <strong>pref + city + ward(存在時) + oaza_cho + machiaza_typeが2なら chome_number + 「丁目」</strong><br>
                 2列目: <strong>pref + city + ward(存在時)</strong><br>
 
-                市町村名を指定すると、その市町村に一致する行だけ抽出します。政令指定都市は <strong>京都市</strong> のように市名だけを指定しても、その市に属するすべての区をまとめて抽出できます。
-                3列目: <strong>住所に○丁目が含まれていない場合のみ「丁目」</strong>
+                市町村名を指定すると、その市町村に一致する行だけ抽出します。複数指定する場合は <strong>カンマ / 読点 / セミコロン</strong> 区切りで入力できます。政令指定都市は <strong>京都市</strong> のように市名だけを指定しても、その市に属するすべての区をまとめて抽出できます。
+                3列目: <strong>住所に○丁目が含まれていない場合のみ「丁目」</strong><br>
+                差分比較では、貼り付けたCSVから抽出した対象市区町村の住所一覧を、<strong>既存の全境界データ（広島市 / 倉敷市 / 京都市 / 埼玉西部）</strong> と照合します。
             </div>
 
             <div class="result-box filter-box">
@@ -203,20 +257,24 @@
                 <select id="boundary-dataset-select">
                     <option value="">境界データを選択してください</option>
                 </select>
-                <div class="sub-note">例: 広島市、京都市、埼玉西部</div>
+                <div class="sub-note">例: 広島市、倉敷市、京都市、埼玉西部</div>
                 <div class="button-row">
                     <button id="build-from-boundary-btn" type="button">選択した境界データから作成</button>
                 </div>
             </div>
 
             <div class="result-box filter-box">
-                <label for="municipality-filter"><strong>抽出対象の市町村名（任意）</strong></label>
-                <input id="municipality-filter" type="text" placeholder="例: 京都市 / 京都市中京区 / 横浜市 / 札幌市中央区">
+                <label for="municipality-filter"><strong>抽出対象の市町村名（任意・複数指定可）</strong></label>
+                <input id="municipality-filter" type="text" placeholder="例: 京都市, 京都市中京区, 横浜市">
             </div>
 
-            <textarea id="csv-input" placeholder="lg_code,machiaza_id,machiaza_type,pref,... のCSVをここに貼り付け"></textarea>
+            <div id="csv-drop-zone" class="drop-zone">
+                <textarea id="csv-input" placeholder="lg_code,machiaza_id,machiaza_type,pref,... のCSVをここに貼り付け、またはCSVファイルをここへドラッグ＆ドロップ"></textarea>
+            </div>
+            <div class="sub-note">CSVファイルをドラッグ＆ドロップすると内容を自動で読み込みます。</div>
             <div class="button-row">
                 <button id="extract-btn">住所を抽出する</button>
+                <button id="compare-btn" type="button">既存データとの差分を比較する</button>
                 <button id="copy-results-btn" class="success">抽出結果をコピー</button>
                 <button id="clear-btn" class="secondary">入力と結果をクリア</button>
             </div>
@@ -233,6 +291,7 @@
                     <h2>1列目: 詳細住所</h2>
                     <textarea id="column1-output" readonly placeholder="広島県広島市西区井口1丁目"></textarea>
                     <button id="copy-column1-btn" class="success">1列目をコピー</button>
+                    <button id="copy-column1-without-oaza-btn" type="button">大字・字なしでコピー</button>
                 </div>
                 <div class="result-box">
                     <h2>2列目: 市区町村住所</h2>
@@ -246,6 +305,58 @@
                 </div>
             </div>
         </section>
+
+        <section class="card">
+            <div class="result-box">
+                <h2>差分比較結果</h2>
+                <div class="sub-note">比較時は市区町村名を入力してください。詳細住所ベースで比較し、既存データは全境界データを横断して照合します。</div>
+            </div>
+            <div class="meta">
+                <div>ABRにのみ存在: <strong id="abr-only-count">0</strong></div>
+                <div>既存データにのみ存在: <strong id="boundary-only-count">0</strong></div>
+            </div>
+            <div class="result-grid two-column">
+                <div class="result-box">
+                    <h2>ABRにあるが既存データにない住所</h2>
+                    <textarea id="abr-only-output" readonly placeholder="広島県広島市西区井口1丁目"></textarea>
+                    <button id="copy-abr-only-btn" class="success">ABR差分をコピー</button>
+                </div>
+                <div class="result-box">
+                    <h2>既存データにあるがABRにない住所</h2>
+                    <textarea id="boundary-only-output" readonly placeholder="広島県広島市西区井口町"></textarea>
+                    <button id="copy-boundary-only-btn" class="success">既存データ差分をコピー</button>
+                </div>
+            </div>
+        </section>
+        </div>
+
+        <div id="duplicate-panel" class="tool-panel">
+            <section class="card">
+                <div class="description">
+                    住所一覧を貼り付けると、同一の住所が何件重複しているかを集計します。<br>
+                    改行区切りで判定し、前後の空白は無視します。
+                </div>
+                <textarea id="duplicate-input" placeholder="住所一覧を1行ずつ貼り付け"></textarea>
+                <div class="button-row">
+                    <button id="check-duplicates-btn" type="button">重複をチェックする</button>
+                    <button id="copy-duplicate-results-btn" class="success" type="button">重複一覧をコピー</button>
+                    <button id="clear-duplicate-btn" class="secondary" type="button">重複チェックをクリア</button>
+                </div>
+                <div id="duplicate-status" class="status"></div>
+                <div class="meta">
+                    <div>入力行数: <strong id="duplicate-total-count">0</strong></div>
+                    <div>重複住所数: <strong id="duplicate-address-count">0</strong></div>
+                    <div>重複行数: <strong id="duplicate-extra-count">0</strong></div>
+                </div>
+            </section>
+
+            <section class="card">
+                <div class="result-box">
+                    <h2>重複一覧</h2>
+                    <textarea id="duplicate-output" readonly placeholder="東京都千代田区丸の内1丁目\t3件"></textarea>
+                </div>
+            </section>
+        </div>
     </div>
 
     <script src="js/town-boundary-datasets.js"></script>

--- a/address-tool.js
+++ b/address-tool.js
@@ -5,14 +5,29 @@ const REQUIRED_COLUMNS = ["pref", "city", "ward", "oaza_cho", "machiaza_type", "
 const MAX_PERSISTED_CSV_LENGTH = 150000;
 
 const csvInput = document.getElementById("csv-input");
+const csvDropZone = document.getElementById("csv-drop-zone");
 const municipalityFilterInput = document.getElementById("municipality-filter");
 const boundaryDatasetSelect = document.getElementById("boundary-dataset-select");
+const extractTabButton = document.getElementById("extract-tab-btn");
+const duplicateTabButton = document.getElementById("duplicate-tab-btn");
+const extractPanel = document.getElementById("extract-panel");
+const duplicatePanel = document.getElementById("duplicate-panel");
 const column1Output = document.getElementById("column1-output");
 const column2Output = document.getElementById("column2-output");
 const column3Output = document.getElementById("column3-output");
+const abrOnlyOutput = document.getElementById("abr-only-output");
+const boundaryOnlyOutput = document.getElementById("boundary-only-output");
 const statusEl = document.getElementById("status");
 const processedCountEl = document.getElementById("processed-count");
 const outputCountEl = document.getElementById("output-count");
+const abrOnlyCountEl = document.getElementById("abr-only-count");
+const boundaryOnlyCountEl = document.getElementById("boundary-only-count");
+const duplicateInput = document.getElementById("duplicate-input");
+const duplicateOutput = document.getElementById("duplicate-output");
+const duplicateStatusEl = document.getElementById("duplicate-status");
+const duplicateTotalCountEl = document.getElementById("duplicate-total-count");
+const duplicateAddressCountEl = document.getElementById("duplicate-address-count");
+const duplicateExtraCountEl = document.getElementById("duplicate-extra-count");
 const boundaryDatasetCache = new Map();
 const boundaryDatasetPendingLoads = new Map();
 
@@ -24,6 +39,15 @@ function normalizeMunicipalityName(value) {
     return normalizeValue(value).replace(/[\s　]+/g, "");
 }
 
+function parseMunicipalityFilters(value) {
+    return Array.from(new Set(
+        normalizeValue(value)
+            .split(/[\r\n,、;；]+/)
+            .map((part) => normalizeMunicipalityName(part))
+            .filter(Boolean)
+    ));
+}
+
 function setStatus(message, type = "") {
     statusEl.textContent = message;
     statusEl.className = `status ${type}`.trim();
@@ -32,6 +56,29 @@ function setStatus(message, type = "") {
 function setCounts(processed, output) {
     processedCountEl.textContent = String(processed);
     outputCountEl.textContent = String(output);
+}
+
+function setDuplicateStatus(message, type = "") {
+    if (!duplicateStatusEl) {
+        return;
+    }
+
+    duplicateStatusEl.textContent = message;
+    duplicateStatusEl.className = `status ${type}`.trim();
+}
+
+function setDuplicateCounts(totalCount, duplicateAddressCount, duplicateExtraCount) {
+    if (duplicateTotalCountEl) {
+        duplicateTotalCountEl.textContent = String(totalCount);
+    }
+
+    if (duplicateAddressCountEl) {
+        duplicateAddressCountEl.textContent = String(duplicateAddressCount);
+    }
+
+    if (duplicateExtraCountEl) {
+        duplicateExtraCountEl.textContent = String(duplicateExtraCount);
+    }
 }
 
 function getStoredValue(key) {
@@ -112,6 +159,83 @@ function appendStorageNotice(message, notice) {
     return notice ? `${message} ${notice}` : message;
 }
 
+function setDropZoneActive(isActive) {
+    if (!csvDropZone) {
+        return;
+    }
+
+    csvDropZone.classList.toggle("is-dragover", Boolean(isActive));
+}
+
+function readCsvFile(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+            resolve(typeof reader.result === "string" ? reader.result : "");
+        };
+        reader.onerror = () => {
+            reject(new Error("CSVファイルの読み込みに失敗しました。"));
+        };
+        reader.readAsText(file, "utf-8");
+    });
+}
+
+async function loadCsvFile(file) {
+    if (!file) {
+        setStatus("CSVファイルを選択してください。", "error");
+        return;
+    }
+
+    const fileName = normalizeValue(file.name);
+    if (fileName && !/\.csv$/i.test(fileName) && normalizeValue(file.type) !== "text/csv") {
+        setStatus("CSVファイルをドロップしてください。", "error");
+        return;
+    }
+
+    try {
+        const fileText = await readCsvFile(file);
+        csvInput.value = fileText;
+        const storageNotice = persistCsvInput(fileText);
+        resetOutputs();
+        resetComparisonOutputs();
+        setStatus(
+            appendStorageNotice(
+                fileName ? `CSVファイル「${fileName}」を読み込みました。` : "CSVファイルを読み込みました。",
+                storageNotice
+            ),
+            "success"
+        );
+    } catch (error) {
+        setStatus(error.message || "CSVファイルの読み込みに失敗しました。", "error");
+    }
+}
+
+function handleDropZoneDragOver(event) {
+    event.preventDefault();
+    setDropZoneActive(true);
+}
+
+function handleDropZoneDragLeave(event) {
+    if (!csvDropZone || csvDropZone.contains(event.relatedTarget)) {
+        return;
+    }
+
+    setDropZoneActive(false);
+}
+
+function handleDropZoneDrop(event) {
+    event.preventDefault();
+    setDropZoneActive(false);
+
+    const files = event.dataTransfer && event.dataTransfer.files;
+    if (!files || !files.length) {
+        setStatus("ドロップされたファイルを確認できませんでした。", "error");
+        return;
+    }
+
+    loadCsvFile(files[0]);
+}
+
 function restoreInput() {
     const savedCsv = getStoredValue(ADDRESS_TOOL_STORAGE_KEY);
     const savedFilter = getStoredValue(MUNICIPALITY_FILTER_STORAGE_KEY);
@@ -145,6 +269,26 @@ function formatChomeColumn(type) {
 
 function joinAddressParts(parts) {
     return parts.map(normalizeValue).filter(Boolean).join("");
+}
+
+function normalizeTownNameWithoutOazaAza(value) {
+    let normalized = normalizeValue(value);
+
+    while (/^(大字|字)/.test(normalized)) {
+        normalized = normalized.replace(/^(大字|字)/, "");
+    }
+
+    return normalized;
+}
+
+function normalizeAddressComparisonKey(value) {
+    return normalizeValue(value).replace(/[\s　]+/g, "");
+}
+
+function sortAddressRows(rows) {
+    return rows
+        .slice()
+        .sort((a, b) => normalizeValue(a.detailedAddress).localeCompare(normalizeValue(b.detailedAddress), "ja"));
 }
 
 function parseCsv(text) {
@@ -235,16 +379,47 @@ function buildMunicipalityCandidates(pref, city, ward) {
 }
 
 function matchesMunicipalityFilter(filterValue, pref, city, ward) {
-    const normalizedFilter = normalizeMunicipalityName(filterValue);
-    if (!normalizedFilter) {
+    const normalizedFilters = parseMunicipalityFilters(filterValue);
+    if (!normalizedFilters.length) {
         return true;
     }
 
-    return buildMunicipalityCandidates(pref, city, ward).has(normalizedFilter);
+    const candidates = buildMunicipalityCandidates(pref, city, ward);
+    return normalizedFilters.some((normalizedFilter) => candidates.has(normalizedFilter));
 }
 
 function getFilterValue() {
     return municipalityFilterInput ? normalizeValue(municipalityFilterInput.value) : "";
+}
+
+function switchToolTab(tabName) {
+    const isDuplicateTab = tabName === "duplicate";
+
+    if (extractTabButton) {
+        extractTabButton.classList.toggle("is-active", !isDuplicateTab);
+    }
+
+    if (duplicateTabButton) {
+        duplicateTabButton.classList.toggle("is-active", isDuplicateTab);
+    }
+
+    if (extractPanel) {
+        extractPanel.classList.toggle("is-active", !isDuplicateTab);
+    }
+
+    if (duplicatePanel) {
+        duplicatePanel.classList.toggle("is-active", isDuplicateTab);
+    }
+}
+
+function setComparisonCounts(abrOnlyCount, boundaryOnlyCount) {
+    if (abrOnlyCountEl) {
+        abrOnlyCountEl.textContent = String(abrOnlyCount);
+    }
+
+    if (boundaryOnlyCountEl) {
+        boundaryOnlyCountEl.textContent = String(boundaryOnlyCount);
+    }
 }
 
 function getBoundaryDatasetDefinitions() {
@@ -386,21 +561,186 @@ function buildBoundaryAddressRows(features, municipalityFilter) {
 
         uniqueRows.set(recordKey, {
             detailedAddress: joinAddressParts([pref, cityName, townName]),
+            detailedAddressWithoutOazaAza: joinAddressParts([pref, cityName, normalizeTownNameWithoutOazaAza(townName)]),
             municipalityAddress: joinAddressParts([pref, cityName]),
             chomeColumnValue: townName.includes("丁目") ? "" : "丁目"
         });
     });
 
-    return Array.from(uniqueRows.values())
-        .filter((row) => row.detailedAddress || row.municipalityAddress)
-        .sort((a, b) => a.detailedAddress.localeCompare(b.detailedAddress, "ja"));
+    return sortAddressRows(
+        Array.from(uniqueRows.values())
+            .filter((row) => row.detailedAddress || row.municipalityAddress)
+    );
 }
 
 function resetOutputs() {
     column1Output.value = "";
+    column1Output.dataset.withoutOazaAza = "";
     column2Output.value = "";
     column3Output.value = "";
     setCounts(0, 0);
+}
+
+function resetComparisonOutputs() {
+    if (abrOnlyOutput) {
+        abrOnlyOutput.value = "";
+    }
+
+    if (boundaryOnlyOutput) {
+        boundaryOnlyOutput.value = "";
+    }
+
+    setComparisonCounts(0, 0);
+}
+
+function resetDuplicateOutputs() {
+    if (duplicateOutput) {
+        duplicateOutput.value = "";
+    }
+
+    setDuplicateCounts(0, 0, 0);
+    setDuplicateStatus("", "");
+}
+
+function setMainOutputs(rows, processedCount) {
+    column1Output.value = rows.map((row) => row.detailedAddress).join("\n");
+    column1Output.dataset.withoutOazaAza = rows
+        .map((row) => row.detailedAddressWithoutOazaAza || row.detailedAddress)
+        .join("\n");
+    column2Output.value = rows.map((row) => row.municipalityAddress).join("\n");
+    column3Output.value = rows.map((row) => row.chomeColumnValue).join("\n");
+    setCounts(processedCount, rows.length);
+}
+
+function setComparisonOutputs(abrOnlyRows, boundaryOnlyRows) {
+    if (abrOnlyOutput) {
+        abrOnlyOutput.value = abrOnlyRows.map((row) => row.detailedAddress).join("\n");
+    }
+
+    if (boundaryOnlyOutput) {
+        boundaryOnlyOutput.value = boundaryOnlyRows.map((row) => row.detailedAddress).join("\n");
+    }
+
+    setComparisonCounts(abrOnlyRows.length, boundaryOnlyRows.length);
+}
+
+function parseDuplicateInputLines(rawText) {
+    return normalizeValue(rawText)
+        .split(/\r?\n/)
+        .map((line) => normalizeValue(line))
+        .filter(Boolean);
+}
+
+function buildCsvAddressRows(rawText, municipalityFilter) {
+    const normalizedText = normalizeValue(rawText);
+    if (!normalizedText) {
+        throw new Error("CSVを貼り付けてください。");
+    }
+
+    const parsedRows = parseCsv(normalizedText);
+    if (parsedRows.length < 2) {
+        throw new Error("ヘッダー行とデータ行を含むCSVを貼り付けてください。");
+    }
+
+    const headerRow = parsedRows[0].map(normalizeValue);
+    const indexMap = buildColumnIndexMap(headerRow);
+    ensureRequiredColumns(indexMap);
+
+    const dataRows = parsedRows.slice(1);
+    const filteredRows = dataRows.filter((row) => matchesMunicipalityFilter(
+        municipalityFilter,
+        row[indexMap.pref],
+        row[indexMap.city],
+        row[indexMap.ward]
+    ));
+
+    const rows = [];
+
+    filteredRows.forEach((row) => {
+        const pref = normalizeValue(row[indexMap.pref]);
+        const city = normalizeValue(row[indexMap.city]);
+        const ward = normalizeValue(row[indexMap.ward]);
+        const oazaCho = normalizeValue(row[indexMap.oaza_cho]);
+        const machiazaType = normalizeValue(row[indexMap.machiaza_type]);
+        const chomeNumber = normalizeValue(row[indexMap.chome_number]);
+
+        const municipalityAddress = joinAddressParts([pref, city, ward]);
+        const detailedAddress = joinAddressParts([
+            pref,
+            city,
+            ward,
+            oazaCho,
+            formatChome(machiazaType, chomeNumber)
+        ]);
+
+        if (!municipalityAddress && !detailedAddress) {
+            return;
+        }
+
+        rows.push({
+            detailedAddress,
+            detailedAddressWithoutOazaAza: joinAddressParts([
+                pref,
+                city,
+                ward,
+                normalizeTownNameWithoutOazaAza(oazaCho),
+                formatChome(machiazaType, chomeNumber)
+            ]),
+            municipalityAddress,
+            chomeColumnValue: formatChomeColumn(machiazaType)
+        });
+    });
+
+    return {
+        filteredRowCount: filteredRows.length,
+        rows
+    };
+}
+
+function buildUniqueAddressRows(rows) {
+    const uniqueRows = new Map();
+
+    rows.forEach((row) => {
+        const comparisonKey = normalizeAddressComparisonKey(row && row.detailedAddress);
+        if (!comparisonKey || uniqueRows.has(comparisonKey)) {
+            return;
+        }
+
+        uniqueRows.set(comparisonKey, row);
+    });
+
+    return uniqueRows;
+}
+
+async function buildAllBoundaryAddressRows(municipalityFilter) {
+    const definitions = getBoundaryDatasetDefinitions();
+    const results = await Promise.all(definitions.map(async (definition) => {
+        const data = await ensureBoundaryDataset(definition);
+        const features = Array.isArray(data && data.features) ? data.features : [];
+        return {
+            definition,
+            rows: buildBoundaryAddressRows(features, municipalityFilter)
+        };
+    }));
+
+    const matchedDefinitions = results.filter((result) => result.rows.length > 0);
+    const uniqueRows = new Map();
+
+    matchedDefinitions.forEach((result) => {
+        result.rows.forEach((row) => {
+            const comparisonKey = normalizeAddressComparisonKey(row.detailedAddress);
+            if (!comparisonKey || uniqueRows.has(comparisonKey)) {
+                return;
+            }
+
+            uniqueRows.set(comparisonKey, row);
+        });
+    });
+
+    return {
+        labels: matchedDefinitions.map((result) => result.definition.label || result.definition.key),
+        rows: sortAddressRows(Array.from(uniqueRows.values()))
+    };
 }
 
 function extractAddresses() {
@@ -412,73 +752,27 @@ function extractAddresses() {
 
     if (!rawText) {
         resetOutputs();
+        resetComparisonOutputs();
         setStatus(appendStorageNotice("CSVを貼り付けてください。", storageNotice), "error");
         return;
     }
 
     try {
-        const parsedRows = parseCsv(rawText);
-        if (parsedRows.length < 2) {
-            throw new Error("ヘッダー行とデータ行を含むCSVを貼り付けてください。");
-        }
-
-        const headerRow = parsedRows[0].map(normalizeValue);
-        const indexMap = buildColumnIndexMap(headerRow);
-        ensureRequiredColumns(indexMap);
-
-        const dataRows = parsedRows.slice(1);
-        const filteredRows = dataRows.filter((row) => matchesMunicipalityFilter(
-            municipalityFilter,
-            row[indexMap.pref],
-            row[indexMap.city],
-            row[indexMap.ward]
-        ));
-
-        const detailedAddresses = [];
-        const municipalityAddresses = [];
-        const chomeColumnValues = [];
-
-        filteredRows.forEach((row) => {
-            const pref = normalizeValue(row[indexMap.pref]);
-            const city = normalizeValue(row[indexMap.city]);
-            const ward = normalizeValue(row[indexMap.ward]);
-            const oazaCho = normalizeValue(row[indexMap.oaza_cho]);
-            const machiazaType = normalizeValue(row[indexMap.machiaza_type]);
-            const chomeNumber = normalizeValue(row[indexMap.chome_number]);
-
-            const municipalityAddress = joinAddressParts([pref, city, ward]);
-            const detailedAddress = joinAddressParts([
-                pref,
-                city,
-                ward,
-                oazaCho,
-                formatChome(machiazaType, chomeNumber)
-            ]);
-
-            if (!municipalityAddress && !detailedAddress) {
-                return;
-            }
-
-            detailedAddresses.push(detailedAddress);
-            municipalityAddresses.push(municipalityAddress);
-            chomeColumnValues.push(formatChomeColumn(machiazaType));
-        });
-
-        column1Output.value = detailedAddresses.join("\n");
-        column2Output.value = municipalityAddresses.join("\n");
-        column3Output.value = chomeColumnValues.join("\n");
-        setCounts(filteredRows.length, detailedAddresses.length);
+        const { filteredRowCount, rows } = buildCsvAddressRows(rawText, municipalityFilter);
+        setMainOutputs(rows, filteredRowCount);
+        resetComparisonOutputs();
         setStatus(
             appendStorageNotice(
                 municipalityFilter
-                    ? `「${municipalityFilter}」に一致する住所を抽出しました（${detailedAddresses.length}件）。`
-                    : `住所を抽出しました（${detailedAddresses.length}件）。`,
+                    ? `「${municipalityFilter}」に一致する住所を抽出しました（${rows.length}件）。`
+                    : `住所を抽出しました（${rows.length}件）。`,
                 storageNotice
             ),
             "success"
         );
     } catch (error) {
         resetOutputs();
+        resetComparisonOutputs();
         setStatus(appendStorageNotice(error.message || "抽出に失敗しました。", storageNotice), "error");
     }
 }
@@ -505,6 +799,7 @@ async function buildAddressesFromBoundaryDataset() {
 
         if (!rows.length) {
             resetOutputs();
+            resetComparisonOutputs();
             setStatus(
                 municipalityFilter
                     ? `境界データ「${definition.label || definition.key}」内に「${municipalityFilter}」に一致する住所がありません。`
@@ -514,10 +809,8 @@ async function buildAddressesFromBoundaryDataset() {
             return;
         }
 
-        column1Output.value = rows.map((row) => row.detailedAddress).join("\n");
-        column2Output.value = rows.map((row) => row.municipalityAddress).join("\n");
-        column3Output.value = rows.map((row) => row.chomeColumnValue).join("\n");
-        setCounts(rows.length, rows.length);
+        setMainOutputs(rows, rows.length);
+        resetComparisonOutputs();
         setStatus(
             municipalityFilter
                 ? `境界データ「${definition.label || definition.key}」から「${municipalityFilter}」に一致する住所を作成しました（${rows.length}件）。`
@@ -526,7 +819,74 @@ async function buildAddressesFromBoundaryDataset() {
         );
     } catch (error) {
         resetOutputs();
+        resetComparisonOutputs();
         setStatus(error.message || "境界データからの作成に失敗しました。", "error");
+    }
+}
+
+async function compareWithExistingBoundaryData() {
+    const rawText = normalizeValue(csvInput.value);
+    const municipalityFilter = getFilterValue();
+    const storageNotice = persistCsvInput(csvInput.value);
+
+    persistMunicipalityFilter(municipalityFilter);
+
+    if (!rawText) {
+        resetComparisonOutputs();
+        setStatus(appendStorageNotice("比較するには先にCSVを貼り付けてください。", storageNotice), "error");
+        return;
+    }
+
+    if (!municipalityFilter) {
+        resetComparisonOutputs();
+        setStatus(appendStorageNotice("比較するには抽出対象の市町村名を入力してください。", storageNotice), "error");
+        return;
+    }
+
+    setStatus(`「${municipalityFilter}」のABR住所一覧と既存境界データを比較しています...`);
+
+    try {
+        const csvResult = buildCsvAddressRows(rawText, municipalityFilter);
+        const abrRows = sortAddressRows(Array.from(buildUniqueAddressRows(csvResult.rows).values()));
+        if (!abrRows.length) {
+            resetComparisonOutputs();
+            setStatus(
+                appendStorageNotice(`CSV内に「${municipalityFilter}」に一致する住所がありません。`, storageNotice),
+                "error"
+            );
+            return;
+        }
+
+        const boundaryResult = await buildAllBoundaryAddressRows(municipalityFilter);
+        const boundaryRows = boundaryResult.rows;
+        const abrMap = buildUniqueAddressRows(abrRows);
+        const boundaryMap = buildUniqueAddressRows(boundaryRows);
+        const abrOnlyRows = sortAddressRows(
+            Array.from(abrMap.entries())
+                .filter(([comparisonKey]) => !boundaryMap.has(comparisonKey))
+                .map(([, row]) => row)
+        );
+        const boundaryOnlyRows = sortAddressRows(
+            Array.from(boundaryMap.entries())
+                .filter(([comparisonKey]) => !abrMap.has(comparisonKey))
+                .map(([, row]) => row)
+        );
+
+        setComparisonOutputs(abrOnlyRows, boundaryOnlyRows);
+
+        const sourceLabel = boundaryResult.labels.length
+            ? `既存データ: ${boundaryResult.labels.join(" / ")}`
+            : "既存データ側に一致する境界データはありませんでした";
+        setStatus(
+            appendStorageNotice(
+                `比較が完了しました。ABRのみ ${abrOnlyRows.length}件 / 既存データのみ ${boundaryOnlyRows.length}件。${sourceLabel}。`,
+                storageNotice
+            ),
+            "success"
+        );
+    } catch (error) {
+        resetComparisonOutputs();
+        setStatus(appendStorageNotice(error.message || "差分比較に失敗しました。", storageNotice), "error");
     }
 }
 
@@ -571,6 +931,79 @@ function copyColumn(outputEl, columnLabel) {
     copyText(text, `${columnLabel}をコピーしました。`);
 }
 
+function copyColumn1WithoutOazaAza() {
+    const text = normalizeValue(column1Output.dataset.withoutOazaAza);
+
+    if (!text) {
+        setStatus("1列目にコピーする内容がありません。", "error");
+        return;
+    }
+
+    copyText(text, "1列目（大字・字なし）をコピーしました。");
+}
+
+function checkDuplicates() {
+    const rawText = duplicateInput ? duplicateInput.value : "";
+    const lines = parseDuplicateInputLines(rawText);
+
+    if (!lines.length) {
+        resetDuplicateOutputs();
+        setDuplicateStatus("住所一覧を貼り付けてください。", "error");
+        return;
+    }
+
+    const counts = new Map();
+    lines.forEach((line) => {
+        counts.set(line, (counts.get(line) || 0) + 1);
+    });
+
+    const duplicateEntries = Array.from(counts.entries())
+        .filter(([, count]) => count > 1)
+        .sort((a, b) => {
+            if (b[1] !== a[1]) {
+                return b[1] - a[1];
+            }
+
+            return a[0].localeCompare(b[0], "ja");
+        });
+    const duplicateExtraCount = duplicateEntries.reduce((sum, [, count]) => sum + (count - 1), 0);
+
+    if (duplicateOutput) {
+        duplicateOutput.value = duplicateEntries
+            .map(([address, count]) => `${address}\t${count}件`)
+            .join("\n");
+    }
+
+    setDuplicateCounts(lines.length, duplicateEntries.length, duplicateExtraCount);
+    setDuplicateStatus(
+        duplicateEntries.length
+            ? `重複を検出しました。重複住所数 ${duplicateEntries.length}件 / 重複行数 ${duplicateExtraCount}件。`
+            : "重複は見つかりませんでした。",
+        "success"
+    );
+}
+
+function copyDuplicateResults() {
+    const text = duplicateOutput ? normalizeValue(duplicateOutput.value) : "";
+
+    if (!text) {
+        setDuplicateStatus("コピーする重複一覧がありません。", "error");
+        return;
+    }
+
+    copyText(text, "重複一覧をコピーしました。");
+    setDuplicateStatus("重複一覧をコピーしました。", "success");
+}
+
+function clearDuplicateChecker() {
+    if (duplicateInput) {
+        duplicateInput.value = "";
+    }
+
+    resetDuplicateOutputs();
+    setDuplicateStatus("重複チェックをクリアしました。", "success");
+}
+
 function clearAll() {
     csvInput.value = "";
     if (municipalityFilterInput) {
@@ -581,6 +1014,7 @@ function clearAll() {
     }
 
     resetOutputs();
+    resetComparisonOutputs();
     removeStoredValue(ADDRESS_TOOL_STORAGE_KEY);
     removeStoredValue(MUNICIPALITY_FILTER_STORAGE_KEY);
     removeStoredValue(BOUNDARY_DATASET_STORAGE_KEY);
@@ -590,15 +1024,37 @@ function clearAll() {
 function initializeAddressTool() {
     populateBoundaryDatasetSelect();
     restoreInput();
+    switchToolTab("extract");
+    resetDuplicateOutputs();
+
+    if (csvDropZone) {
+        csvDropZone.addEventListener("dragenter", () => setDropZoneActive(true));
+        csvDropZone.addEventListener("dragover", handleDropZoneDragOver);
+        csvDropZone.addEventListener("dragleave", handleDropZoneDragLeave);
+        csvDropZone.addEventListener("drop", handleDropZoneDrop);
+    }
 }
 
 document.getElementById("extract-btn").addEventListener("click", extractAddresses);
 document.getElementById("build-from-boundary-btn").addEventListener("click", buildAddressesFromBoundaryDataset);
+document.getElementById("compare-btn").addEventListener("click", compareWithExistingBoundaryData);
 document.getElementById("copy-results-btn").addEventListener("click", copyResults);
 document.getElementById("copy-column1-btn").addEventListener("click", () => copyColumn(column1Output, "1列目"));
+document.getElementById("copy-column1-without-oaza-btn").addEventListener("click", copyColumn1WithoutOazaAza);
 document.getElementById("copy-column2-btn").addEventListener("click", () => copyColumn(column2Output, "2列目"));
 document.getElementById("copy-column3-btn").addEventListener("click", () => copyColumn(column3Output, "3列目"));
+document.getElementById("copy-abr-only-btn").addEventListener("click", () => copyColumn(abrOnlyOutput, "ABR差分"));
+document.getElementById("copy-boundary-only-btn").addEventListener("click", () => copyColumn(boundaryOnlyOutput, "既存データ差分"));
 document.getElementById("clear-btn").addEventListener("click", clearAll);
+document.getElementById("check-duplicates-btn").addEventListener("click", checkDuplicates);
+document.getElementById("copy-duplicate-results-btn").addEventListener("click", copyDuplicateResults);
+document.getElementById("clear-duplicate-btn").addEventListener("click", clearDuplicateChecker);
+if (extractTabButton) {
+    extractTabButton.addEventListener("click", () => switchToolTab("extract"));
+}
+if (duplicateTabButton) {
+    duplicateTabButton.addEventListener("click", () => switchToolTab("duplicate"));
+}
 if (boundaryDatasetSelect) {
     boundaryDatasetSelect.addEventListener("change", () => {
         persistBoundaryDatasetSelection(boundaryDatasetSelect.value);


### PR DESCRIPTION
## 概要
- address-tool に ABR CSV と既存境界データを比較する差分機能を追加
- 市区町村フィルターの複数指定、CSV ドラッグ＆ドロップ読込、1列目の大字・字なしコピーを追加
- 住所一覧の重複を確認できるタブを追加

## 変更内容
- `address-tool.html`
  - 抽出・比較 / 重複チェックのタブ UI を追加
  - CSV ドロップ領域、差分比較結果欄、重複チェック欄を追加
  - 1列目の「大字・字なしでコピー」ボタンを追加
- `address-tool.js`
  - ABR CSV 抽出処理を共通化し、既存境界データとの差分比較ロジックを追加
  - 市区町村名の複数指定に対応
  - CSV ファイルのドラッグ＆ドロップ読込を追加
  - 大字・字を除いた詳細住所コピー処理を追加
  - 重複チェック用の集計・コピー・クリア処理を追加

## 確認
- `node --check address-tool.js`

## 補足
- 差分比較は、貼り付けた CSV から抽出した対象市区町村を既存の全境界データに対して横断比較します。
- 重複チェックは改行区切りの住所一覧を対象に、重複住所数と重複行数を表示します。